### PR TITLE
chore: specify Vercel runtime versions

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/node@2.9.5"
+    }
+  ],
+  "functions": {
+    "api/**/*.js": {
+      "runtime": "nodejs18.x"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` with explicit `@vercel/node@2.9.5` build runtime
- set serverless functions to use `nodejs18.x`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b48aae3e0832f8574c50384cf3f28